### PR TITLE
Randomly sample scan points when computing Jacobian

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,7 +17,8 @@ set(SOURCE_FILES
   src/lib.cpp
   src/eigen.cpp
   src/pcl_utils.cpp
-  src/ros_msg.cpp)
+  src/ros_msg.cpp
+  src/random.cpp)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
@@ -45,7 +46,7 @@ if(BUILD_TESTING)
 
   ament_lint_auto_find_test_dependencies()
 
-  file(GLOB FILES_TO_CHECK include/lidar_feature_library/*)
+  file(GLOB FILES_TO_CHECK include/lidar_feature_library/* src/*)
 
   find_package(ament_cmake_cpplint)
   ament_cpplint(${FILES_TO_CHECK})

--- a/lib/include/lidar_feature_library/random.hpp
+++ b/lib/include/lidar_feature_library/random.hpp
@@ -1,0 +1,36 @@
+// Copyright 2022 Tixiao Shan, Takeshi Ishita
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Tixiao Shan, Takeshi Ishita nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef LIDAR_FEATURE_LIBRARY__RANDOM_HPP_
+#define LIDAR_FEATURE_LIBRARY__RANDOM_HPP_
+
+#include <vector>
+
+std::vector<size_t> RandomizedUniqueIndices(const size_t size);
+
+#endif  // LIDAR_FEATURE_LIBRARY__RANDOM_HPP_

--- a/lib/src/random.cpp
+++ b/lib/src/random.cpp
@@ -1,0 +1,42 @@
+// Copyright 2022 Tixiao Shan, Takeshi Ishita
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Tixiao Shan, Takeshi Ishita nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+#include "lidar_feature_library/random.hpp"
+
+
+std::vector<size_t> RandomizedUniqueIndices(const size_t size)
+{
+  std::vector<size_t> v(size);
+  std::iota(v.begin(), v.end(), 0);
+  std::shuffle(v.begin(), v.end(), std::mt19937{std::random_device{}()});
+  return v;
+}

--- a/lib/test/test_random.cpp
+++ b/lib/test/test_random.cpp
@@ -1,0 +1,66 @@
+// Copyright 2022 Tixiao Shan, Takeshi Ishita
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Tixiao Shan, Takeshi Ishita nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+#include <gmock/gmock.h>
+
+#include <unordered_set>
+
+#include "lidar_feature_library/random.hpp"
+
+
+TEST(RandomizedUniqueIndices, SmokeTest)
+{
+  std::srand(3939);
+
+  const size_t size = 40;
+  const std::vector<size_t> indices = RandomizedUniqueIndices(size);
+
+  ASSERT_EQ(indices.size(), size);
+
+  const size_t min = *std::min_element(indices.begin(), indices.end());
+  const size_t max = *std::max_element(indices.begin(), indices.end());
+  ASSERT_EQ(min, 0U);
+  ASSERT_EQ(max, size-1);
+
+  // checks if indices are randomized
+  ASSERT_NE(indices.at(0), 0U);
+  ASSERT_NE(indices.at(size-1), size-1);
+
+  std::unordered_set<size_t> unique;
+  for (const size_t i : indices) {
+    unique.insert(i);
+  }
+
+  ASSERT_EQ(unique.size(), size);
+}
+
+TEST(RandomizedUniqueIndices, Empty)
+{
+  ASSERT_EQ(RandomizedUniqueIndices(0).size(), 0U);
+}


### PR DESCRIPTION
As the same idea as the stochastic gradient descent, we randomly select scan points when computing Jacobian to improve the computation speed and achieve more robust convergence.