### PR TITLE
Add a class to capture transform from tf 

### DIFF
--- a/ekf_localizer/CMakeLists.txt
+++ b/ekf_localizer/CMakeLists.txt
@@ -42,6 +42,7 @@ if(BUILD_TESTING)
     test/test_ekf_localizer.cpp
     test/test_mahalanobis.cpp
     test/test_string.cpp
+    test/test_tf.cpp
     test/test_update_interval.cpp)
 
   foreach(filepath ${TEST_FILES})

--- a/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -39,6 +39,7 @@
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
+#include "ekf_localizer/tf.hpp"
 #include "ekf_localizer/update_interval.hpp"
 #include "ekf_localizer/warning.hpp"
 
@@ -197,6 +198,8 @@ public:
 private:
   const Warning warning_;
 
+  const TransformListener listener_;
+
   //!< @brief estimated ekf odometry publisher
   const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_;
   //!< @brief ekf estimated yaw bias publisher
@@ -253,6 +256,7 @@ private:
   const double wz_covariance_;        //!< @brief  wz process noise
 
   const DefaultVariance variance_;
+
   TimeDelayKalmanFilter ekf_;
 
   AgedMessageQueue<PoseWithCovarianceStamped::SharedPtr> pose_messages_;

--- a/ekf_localizer/include/ekf_localizer/tf.hpp
+++ b/ekf_localizer/include/ekf_localizer/tf.hpp
@@ -26,7 +26,7 @@
 
 
 bool getTransformFromTF(
-  const Warning & warning_,
+  std::shared_ptr<rclcpp::Node> node,
   const std::string & parent_frame,
   const std::string & child_frame,
   geometry_msgs::msg::TransformStamped & transform);

--- a/ekf_localizer/include/ekf_localizer/tf.hpp
+++ b/ekf_localizer/include/ekf_localizer/tf.hpp
@@ -29,10 +29,10 @@
 class TransformListener
 {
 public:
-  TransformListener(std::shared_ptr<rclcpp::Node> node)
+  TransformListener(rclcpp::Node * node)
   : tf_buffer_(std::make_shared<tf2::BufferCore>()),
     listener_(*tf_buffer_, node, false),
-    warning_(std::make_shared<Warning>(node.get()))
+    warning_(std::make_shared<Warning>(node))
   {
   }
 

--- a/ekf_localizer/include/ekf_localizer/tf.hpp
+++ b/ekf_localizer/include/ekf_localizer/tf.hpp
@@ -20,16 +20,30 @@
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 
+#include <memory>
 #include <string>
 
 #include "ekf_localizer/warning.hpp"
 
 
-bool getTransformFromTF(
-  std::shared_ptr<rclcpp::Node> node,
-  const std::string & parent_frame,
-  const std::string & child_frame,
-  geometry_msgs::msg::TransformStamped & transform);
+class TransformListener
+{
+public:
+  TransformListener(std::shared_ptr<rclcpp::Node> node)
+  : tf_buffer_(std::make_shared<tf2::BufferCore>()),
+    listener_(*tf_buffer_, node, false),
+    warning_(std::make_shared<Warning>(node.get()))
+  {
+  }
 
+  std::optional<geometry_msgs::msg::TransformStamped> LookupTransform(
+    const std::string & parent_frame,
+    const std::string & child_frame) const;
+
+private:
+  const std::shared_ptr<tf2::BufferCore> tf_buffer_;
+  const tf2_ros::TransformListener listener_;
+  const std::shared_ptr<Warning> warning_;
+};
 
 #endif  // EKF_LOCALIZER__TF_HPP_

--- a/ekf_localizer/src/ekf_localizer.cpp
+++ b/ekf_localizer/src/ekf_localizer.cpp
@@ -177,6 +177,7 @@ TimeDelayKalmanFilter InitEKF(const int extend_state_step_, const double yaw_bia
 EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOptions & node_options)
 : rclcpp::Node(node_name, node_options),
   warning_(this),
+  listener_(this),
   pub_odom_(create_publisher<nav_msgs::msg::Odometry>("ekf_odom", 1)),
   pub_biased_pose_(create_publisher<PoseWithCovarianceStamped>(
       "ekf_biased_pose_with_covariance", 1)),
@@ -529,9 +530,7 @@ void EKFLocalizer::callbackInitialPose(PoseWithCovarianceStamped::SharedPtr init
 {
   geometry_msgs::msg::TransformStamped transform;
 
-  TransformListener listener(this);
-
-  const auto maybe_transform = listener.LookupTransform(
+  const auto maybe_transform = listener_.LookupTransform(
          EraseBeginSlash(pose_frame_id_),
          EraseBeginSlash(initialpose->header.frame_id));
   if (!maybe_transform.has_value()) {

--- a/ekf_localizer/src/ekf_localizer.cpp
+++ b/ekf_localizer/src/ekf_localizer.cpp
@@ -530,7 +530,7 @@ void EKFLocalizer::callbackInitialPose(PoseWithCovarianceStamped::SharedPtr init
   geometry_msgs::msg::TransformStamped transform;
 
   if (!getTransformFromTF(
-         warning_,
+         std::shared_ptr<rclcpp::Node>(this),
          EraseBeginSlash(pose_frame_id_),
          EraseBeginSlash(initialpose->header.frame_id),
          transform)) {

--- a/ekf_localizer/src/ekf_localizer.cpp
+++ b/ekf_localizer/src/ekf_localizer.cpp
@@ -529,7 +529,7 @@ void EKFLocalizer::callbackInitialPose(PoseWithCovarianceStamped::SharedPtr init
 {
   geometry_msgs::msg::TransformStamped transform;
 
-  TransformListener listener(std::shared_ptr<rclcpp::Node>(this));
+  TransformListener listener(this);
 
   const auto maybe_transform = listener.LookupTransform(
          EraseBeginSlash(pose_frame_id_),

--- a/ekf_localizer/src/tf.cpp
+++ b/ekf_localizer/src/tf.cpp
@@ -19,29 +19,20 @@
 
 #include "ekf_localizer/tf.hpp"
 
-
-bool getTransformFromTF(
-  std::shared_ptr<rclcpp::Node> node,
+std::optional<geometry_msgs::msg::TransformStamped> TransformListener::LookupTransform(
   const std::string & parent_frame,
-  const std::string & child_frame,
-  geometry_msgs::msg::TransformStamped & transform)
+  const std::string & child_frame) const
 {
-  tf2::BufferCore tf_buffer;
-  tf2_ros::TransformListener tfl(tf_buffer, node, false);
+  rclcpp::sleep_for(std::chrono::milliseconds(100));
 
-  rclcpp::Rate r(10);
-  rclcpp::spin_some(node);
-
-  for (int i = 0; i < 10; ++i) {
+  for (int i = 0; i < 50; ++i) {
     try {
-      transform = tf_buffer.lookupTransform(parent_frame, child_frame, tf2::TimePointZero);
-      return true;
+      auto transform = tf_buffer_->lookupTransform(parent_frame, child_frame, tf2::TimePointZero);
+      return std::make_optional<geometry_msgs::msg::TransformStamped>(transform);
     } catch (tf2::TransformException & ex) {
-      Warning(node.get()).Warn(ex.what());
+      warning_->Warn(ex.what());
+      rclcpp::sleep_for(std::chrono::milliseconds(100));
     }
-
-    r.sleep();
-    rclcpp::spin_some(node);
   }
-  return false;
+  return std::nullopt;
 }

--- a/ekf_localizer/test/test_tf.cpp
+++ b/ekf_localizer/test/test_tf.cpp
@@ -75,7 +75,7 @@ TEST_F(EKFLocalizerTestSuite, getTransformFromTF)
     broadcaster, broadcaster->get_clock(), std::chrono::milliseconds(100),
     std::bind(&TfBroadcasterNode::Broadcast, broadcaster));
 
-  TransformListener listener(broadcaster);
+  TransformListener listener(broadcaster.get());
 
   rclcpp::Rate r(10);
 

--- a/ekf_localizer/test/test_tf.cpp
+++ b/ekf_localizer/test/test_tf.cpp
@@ -1,0 +1,89 @@
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <gtest/gtest.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <chrono>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "ekf_localizer/tf.hpp"
+
+
+class EKFLocalizerTestSuite : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+class TfBroadcasterNode : public rclcpp::Node
+{
+public:
+  TfBroadcasterNode()
+  : rclcpp::Node("tf_broadcaster"),
+    broadcaster_(std::make_unique<tf2_ros::TransformBroadcaster>(*this))
+  {
+  }
+
+  void Broadcast()
+  {
+    geometry_msgs::msg::TransformStamped transform;
+    transform.header.set__stamp(this->now()).set__frame_id("map");
+    transform.child_frame_id = "base_link";
+    transform.transform.translation.set__x(10.).set__y(20.).set__z(30.);
+    transform.transform.rotation.set__w(1.).set__x(0.).set__y(0.).set__z(0.);
+
+    broadcaster_->sendTransform(transform);
+  }
+
+private:
+  std::unique_ptr<tf2_ros::TransformBroadcaster> broadcaster_;
+};
+
+TEST_F(EKFLocalizerTestSuite, getTransformFromTF)
+{
+  auto broadcaster = std::make_shared<TfBroadcasterNode>();
+
+  auto timer = rclcpp::create_timer(
+    broadcaster, broadcaster->get_clock(), std::chrono::milliseconds(10),
+    std::bind(&TfBroadcasterNode::Broadcast, broadcaster));
+
+  geometry_msgs::msg::TransformStamped recieved;
+
+  EXPECT_TRUE(getTransformFromTF(broadcaster, "map", "base_link", recieved));
+
+  EXPECT_EQ(recieved.transform.translation.x, 10.);
+  EXPECT_EQ(recieved.transform.translation.y, 20.);
+  EXPECT_EQ(recieved.transform.translation.z, 30.);
+  EXPECT_EQ(recieved.transform.rotation.w, 1.);
+  EXPECT_EQ(recieved.transform.rotation.x, 0.);
+  EXPECT_EQ(recieved.transform.rotation.y, 0.);
+  EXPECT_EQ(recieved.transform.rotation.z, 0.);
+}


### PR DESCRIPTION
To capture transform from tf, it is necessary to watch the topic in the place where `tf2_ros::TransformListener` is available.
We add a class whose member is `tf2_ros::TransformListener` and make the lookup available anywhere in the ROS node.