### PR TITLE
Implement the IRLS scale parameter 

### DIFF
--- a/lib/include/lidar_feature_library/stats.hpp
+++ b/lib/include/lidar_feature_library/stats.hpp
@@ -1,0 +1,67 @@
+// Copyright 2022 Tixiao Shan, Takeshi Ishita
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Tixiao Shan, Takeshi Ishita nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef LIDAR_FEATURE_LIBRARY__STATS_HPP_
+#define LIDAR_FEATURE_LIBRARY__STATS_HPP_
+
+#include <Eigen/Core>
+#include <vector>
+
+// private method, because the argument will be modified
+double Median_(std::vector<double> & v)
+{
+  if (v.size() % 2 == 1) {
+    const int n = (v.size() - 1) / 2;
+    std::nth_element(v.begin(), v.begin() + n, v.end());
+    return v[n];
+  }
+
+  const int n = v.size() / 2;
+
+  std::nth_element(v.begin(), v.begin() + n - 0, v.end());
+  const double e0 = v[n - 0];
+
+  std::nth_element(v.begin(), v.begin() + n - 1, v.end());
+  const double e1 = v[n - 1];
+
+  return (e0 + e1) / 2.;
+}
+
+double Median(const Eigen::VectorXd & m)
+{
+  std::vector<double> v(m.begin(), m.end());
+  return Median_(v);
+}
+
+double Median(const Eigen::ArrayXd & m)
+{
+  std::vector<double> v(m.begin(), m.end());
+  return Median_(v);
+}
+
+#endif  // LIDAR_FEATURE_LIBRARY__STATS_HPP_

--- a/lib/test/test_stats.cpp
+++ b/lib/test/test_stats.cpp
@@ -61,4 +61,10 @@ TEST(Median, EvenLengthInput)
     v << -6, -1, -4, -5, -3, -2;
     EXPECT_EQ(Median(v), -3.5);
   }
+
+  {
+    Eigen::VectorXd v(6);
+    v << 4.5, 0.5, 0.5, 3.5, 1.5, 2.5;
+    EXPECT_EQ(Median(v), 2.0);
+  }
 }

--- a/lib/test/test_stats.cpp
+++ b/lib/test/test_stats.cpp
@@ -1,0 +1,64 @@
+// Copyright 2022 Tixiao Shan, Takeshi Ishita
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Tixiao Shan, Takeshi Ishita nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "lidar_feature_library/stats.hpp"
+
+
+TEST(Median, OddLengthInput)
+{
+  {
+    Eigen::VectorXd v(9);
+    v << 7, 8, 2, 0, 5, 1, 3, 4, 6;
+
+    EXPECT_EQ(Median(v), 4);
+  }
+
+  {
+    Eigen::VectorXd v(5);
+    v << 1, 2, -2, -1, 0;
+
+    EXPECT_EQ(Median(v), 0);
+  }
+}
+
+TEST(Median, EvenLengthInput)
+{
+  {
+    Eigen::VectorXd v(10);
+    v << 7, 8, 2, 0, 5, 9, 1, 3, 4, 6;
+    EXPECT_EQ(Median(v), 4.5);
+  }
+
+  {
+    Eigen::VectorXd v(6);
+    v << -6, -1, -4, -5, -3, -2;
+    EXPECT_EQ(Median(v), -3.5);
+  }
+}

--- a/localization/include/lidar_feature_localization/irls.hpp
+++ b/localization/include/lidar_feature_localization/irls.hpp
@@ -31,6 +31,8 @@
 
 #include <Eigen/Core>
 
+double MedianAbsoluteDeviation(const Eigen::VectorXd & v);
+double Scale(const Eigen::VectorXd & v);
 Eigen::VectorXd HuberWeights(const Eigen::VectorXd & residuals, const double k = 1.345);
 
 #endif  // LIDAR_FEATURE_LOCALIZATION__IRLS_HPP_

--- a/localization/include/lidar_feature_localization/optimizer.hpp
+++ b/localization/include/lidar_feature_localization/optimizer.hpp
@@ -92,7 +92,8 @@ public:
 
       r_prev = r;
 
-      const Eigen::VectorXd weights = HuberWeights(r);
+      const double scale = Scale(r);
+      const Eigen::VectorXd weights = HuberWeights(r / (scale + 1e-16));
       const auto [dq, dt] = CalcUpdate(weights, J, r, q);
 
       q = q * dq;

--- a/localization/src/irls.cpp
+++ b/localization/src/irls.cpp
@@ -30,8 +30,25 @@
 
 #include <cmath>
 
+#include "lidar_feature_library/stats.hpp"
 #include "lidar_feature_localization/irls.hpp"
 
+
+double MedianAbsoluteDeviation(const Eigen::VectorXd & v)
+{
+  const double median = Median(v);
+  return Median((v.array() - median).abs().eval());
+}
+
+double Scale(const Eigen::VectorXd & v)
+{
+  // >>> from scipy.stats import norm
+  // >>> 1 / norm.ppf(3 / 4)
+  // 1.482602218505602
+
+  const double b = 1.482602218505602;
+  return b * MedianAbsoluteDeviation(v);
+}
 
 Eigen::VectorXd HuberWeights(const Eigen::VectorXd & residuals, const double k)
 {

--- a/localization/test/test_irls.cpp
+++ b/localization/test/test_irls.cpp
@@ -31,6 +31,30 @@
 
 #include "lidar_feature_localization/irls.hpp"
 
+TEST(IRLS, MedianAbsoluteDeviation)
+{
+  {
+    Eigen::VectorXd v(5);
+    v << 7, 9, 3, 0, 1;
+
+    // median(v) = 3
+    // | v - median(v) | = [4, 6, 0, 3, 2]
+    // median(| v - median(v) |) = 3
+
+    EXPECT_EQ(MedianAbsoluteDeviation(v), 3);
+  }
+
+  {
+    Eigen::VectorXd v(6);
+    v << 8, 3, 4, 0, 5, 1;
+
+    // median(v) = 3.5
+    // | v - median(v) | = [4.5, 0.5, 0.5, 3.5, 1.5, 2.5]
+    // median(| v - median(v) |) = (1.5 + 2.5) / 2 = 2.0
+
+    EXPECT_EQ(MedianAbsoluteDeviation(v), 2.);
+  }
+}
 
 TEST(HuberWeights, HuberWeights)
 {


### PR DESCRIPTION
IRLS in the current `develop` head is not correctly implemented as the scale parameter is not used to normalize the residuals. 
In this PR we add a function to compute the scale parameter and normalize the residual when computing the weights.  